### PR TITLE
add watchify as dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "stream-combiner": "0.0.4",
     "through2": "~0.6.3",
     "toposort": "~0.2.10",
-    "underscore": "~1.6.0"
+    "underscore": "~1.6.0",
+    "watchify": "^3.1.1"
   },
   "devDependencies": {
     "browserify": "^9.0.8",


### PR DESCRIPTION
`Watchify` is required in the `cmd.js` - in theory we could also add it as optional dependency, but this would require a bit more code ;-)