### PR TITLE
Replace globwatcher by chokidar for native fs events

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+_This is a [fork](https://github.com/rotundasoftware/parcelify) with [event-based watch mode](https://github.com/jholster/parcelify/commit/d04e43ed15806e104ba72e43ed835db0ac3104b4). The original README included below._
+
+`npm install parcelify2`
+
+--------------------------
+
 # Parcelify
 
 Add css to your npm modules consumed with [browserify](http://browserify.org/).
@@ -9,7 +15,6 @@ Add css to your npm modules consumed with [browserify](http://browserify.org/).
 
 Many thanks to [James Halliday](https://twitter.com/substack) for his help and guidance in bringing this project into reality.
 
-[![build status](https://secure.travis-ci.org/rotundasoftware/parcelify.png)](https://api.travis-ci.org/rotundasoftware/parcelify.svg?branch=master)
 
 ## How dat work?
 

--- a/lib/package.js
+++ b/lib/package.js
@@ -5,7 +5,7 @@ var EventEmitter = require( 'events' ).EventEmitter;
 var _ = require( 'underscore' );
 var async = require( 'async' );
 var glob = require( 'glob' );
-var globwatcher = require( 'globwatcher' ).globwatcher;
+var chokidar = require( 'chokidar' );
 var Asset = require( './asset' );
 var resolve = require( 'resolve' );
 var log = require( 'npmlog' );
@@ -47,7 +47,7 @@ Package.prototype.createAllAssets = function( assetTypes ) {
 };
 
 Package.prototype.createAsset = function( thisAssetSrcPath, assetType, appData ) {
-	var thisAsset = new Asset( thisAssetSrcPath, assetType, _.clone( this.assetTransformsByType[ assetType ] ), appData );
+	var thisAsset = new Asset( path.normalize(thisAssetSrcPath), assetType, _.clone( this.assetTransformsByType[ assetType ] ), appData );
 
 	log.verbose( '', assetType + ' asset registered "%s"', path.relative( process.cwd(), thisAssetSrcPath ) );
 
@@ -108,8 +108,8 @@ Package.prototype.destroy = function() {
 Package.prototype._createPackageJsonWatcher = function( assetTypes, packageFilter, appTransforms, appTransformDirs ) {
 	var _this = this;
 
-	this.assetJsonWatcher = globwatcher( path.resolve( this.path, "package.json" ) );
-	this.assetJsonWatcher.on( 'changed', function( srcPath ) {
+	this.assetJsonWatcher = chokidar.watch( path.resolve( this.path, "package.json" ) );
+	this.assetJsonWatcher.on( 'change', function( srcPath ) {
 		log.info( 'watch', 'package.json changed "%s"', path.relative( process.cwd(), srcPath ) );
 
 		fs.readFile( srcPath, 'utf8', function( err, packageJson ) {
@@ -147,9 +147,9 @@ Package.prototype._createAssetGlobWatchers = function() {
 	this.assetGlobWatchers = [];
 
 	_.each( _this.assetGlobsByType, function( globs, thisAssetType ) {
-		var thisWatcher = globwatcher( globs );
+		var thisWatcher = chokidar.watch( globs, { ignoreInitial: true } );
 
-		thisWatcher.on( 'changed', function( srcPath ) {
+		thisWatcher.on( 'change', function( srcPath ) {
 			try {
 				log.info( 'watch', '"%s" changed', path.relative( process.cwd(), srcPath ) );
 
@@ -162,14 +162,13 @@ Package.prototype._createAssetGlobWatchers = function() {
 			}
 		} );
 
-		thisWatcher.on( 'added', function( srcPath ) {
+		thisWatcher.on( 'add', function( srcPath ) {
 			try {
 				log.info( 'watch', '"%s" added', path.relative( process.cwd(), srcPath ) );
-			
 				var asset = _.findWhere( _this.assetsByType[ thisAssetType ], { srcPath : srcPath } );
 				// watching is weird... sometimes we get double events. make sure we don't add the same asset twice.
 				if( asset ) return _this.emit( 'error', new Error( 'Asset ' + srcPath + ' already exists in assets of type ' + thisAssetType ) );
-				
+
 				asset = _this.createAsset( srcPath, thisAssetType );
 
 				_this._emitEventOnRelevantParcels( 'assetUpdated', 'added', asset, _this );
@@ -178,7 +177,7 @@ Package.prototype._createAssetGlobWatchers = function() {
 			}
 		} );
 
-		thisWatcher.on( 'deleted', function( srcPath ) {
+		thisWatcher.on( 'unlink', function( srcPath ) {
 			try {
 				log.info( 'watch', '"%s" deleted', path.relative( process.cwd(), srcPath ) );
 
@@ -186,7 +185,7 @@ Package.prototype._createAssetGlobWatchers = function() {
 				if( ! asset ) return _this.emit( 'error', new Error( 'Couldn\'t find changed file ' + srcPath + ' in assets of type ' + thisAssetType ) );
 
 				_this.assetsByType[ thisAssetType ] = _.without( _this.assetsByType[ thisAssetType ], asset );
-			
+
 				_this._emitEventOnRelevantParcels( 'assetUpdated', 'deleted', asset, _this );
 			} catch( err ) {
 				return _this.emit( 'error', err );

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "parcelify2",
-  "version": "2.2.1",
-  "description": "Create css bundles from npm packages using the browserify dependency graph.",
+  "version": "2.2.2",
+  "description": "Create css bundles from npm packages using the browserify dependency graph."D,
   "main": "index.js",
   "bin": {
     "parcelify": "bin/cmd.js"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "parcelify2",
   "version": "2.2.2",
-  "description": "Create css bundles from npm packages using the browserify dependency graph."D,
+  "description": "Create css bundles from npm packages using the browserify dependency graph.",
   "main": "index.js",
   "bin": {
     "parcelify": "bin/cmd.js"

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
   },
   "dependencies": {
     "async": "~0.2.10",
+    "chokidar": "^1.6.1",
     "glob": "~3.2.9",
-    "globwatcher": "~1.2.3",
     "inherits": "~2.0.1",
     "minimist": "0.0.8",
     "mkdirp": "~0.3.5",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "async": "^2.1.5",
     "chokidar": "^1.6.1",
-    "glob": "~7.1.1",
+    "glob": "~7.1.6",
     "inherits": "~2.0.3",
     "minimist": "1.2.0",
     "mkdirp": "~0.5.1",

--- a/package.json
+++ b/package.json
@@ -1,40 +1,40 @@
 {
-  "name": "parcelify",
-  "version": "2.2.0",
+  "name": "parcelify2",
+  "version": "2.2.1",
   "description": "Create css bundles from npm packages using the browserify dependency graph.",
   "main": "index.js",
   "bin": {
     "parcelify": "bin/cmd.js"
   },
   "dependencies": {
-    "async": "~0.2.10",
+    "async": "^2.1.5",
     "chokidar": "^1.6.1",
-    "glob": "~3.2.9",
-    "inherits": "~2.0.1",
-    "minimist": "0.0.8",
-    "mkdirp": "~0.3.5",
-    "npmlog": "0.0.6",
-    "parcel-map": "^3.0.0",
-    "resolve": "~0.6.1",
-    "shasum": "~1.0.1",
+    "glob": "~7.1.1",
+    "inherits": "~2.0.3",
+    "minimist": "1.2.0",
+    "mkdirp": "~0.5.1",
+    "npmlog": "4.0.2",
+    "parcel-map": "^3.0.1",
+    "resolve": "~1.3.2",
+    "shasum": "~1.0.2",
     "stream-combiner": "^0.2.2",
-    "through2": "~0.6.3",
-    "toposort": "~0.2.10",
-    "underscore": "~1.6.0"
+    "through2": "~2.0.3",
+    "toposort": "~1.0.3",
+    "underscore": "~1.8.3"
   },
   "devDependencies": {
-    "browserify": "^9.0.8",
-    "sass-css-stream": "^0.1.4",
-    "tape": "~2.3.2"
+    "browserify": "^14.1.0",
+    "sass-css-stream": "^0.1.6",
+    "tape": "~4.6.3"
   },
   "scripts": {
     "test": "tape test/test.js"
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/rotundasoftware/parcelify.git"
+    "url": "git://github.com/jholster/parcelify.git"
   },
-  "homepage": "https://github.com/rotundasoftware/parcelify",
+  "homepage": "https://github.com/jholster/parcelify",
   "keywords": [
     "parcel",
     "asset",
@@ -43,13 +43,8 @@
     "browserify"
   ],
   "author": {
-    "name": "Rotunda Software",
-    "email": "support@rotundasoftware.com"
+    "name": "Jaakko Holster (originally Rotunda Software)",
+    "email": "holster@iki.fi (originally support@rotundasoftware.com)"
   },
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "https://github.com/rotundasoftware/parcelify/blob/master/LICENSE"
-    }
-  ]
+  "license": "MIT"
 }


### PR DESCRIPTION
Advantages of using chokidar instead of globwatcher:

 - chokidar uses native fs events instead of polling, taking less resources
 - chokidar has excellent cross-platform support, globwatcher is buggy on Windows¹

¹) With globwatcher, I coudn't get parcelify to detect style changes at all on Windows 7 & Windows 10